### PR TITLE
Kleine Verbesserungen

### DIFF
--- a/Vergangenes.md
+++ b/Vergangenes.md
@@ -10,36 +10,52 @@ lang: de
 
 ## Workshops:
 
-* 04.10.2021 6. RDMO-Community-Treffen (virtuell, 3-4 Stunden) [Programm](/events/workshop102021_programm) und [Anmeldung](https://meetings.aip.de/event/13/)
-* 02.09.2021 DMPs in der NFDI - Kick-Off Meeting (virtuell, bei Interesse an RDMO StG schreiben)
-* 02.03.2021 RDMO AG gemeinsam mit NFDI4ING und NFDI-Direktorat [Programm und Slides](/docs/nfdiws/workshop-nfdi), [Bericht](/docs/nfdiws/wsreport)
-* 07.10.2020 4. RDMO-Community-Treffen (virtuell) [Programm](/events/workshop102020_programm), [Bericht](https://www.forschungsdaten.org/index.php/Viertes_Community-Treffen)
-* 24.02.2020 3. RDMO-Community-Treffen, Gründungstreffen als Open Source Projekt, [Programm](/events/workshop022020_programm), [Bericht](https://www.forschungsdaten.org/index.php/Drittes_Community-Treffen)
-* 03.12.2019 Lokaler Workshop in Bonn an der Max Weber Stiftung
-* 07.10.2019 2. Community-Treffen [Programm+Slides](/events/workshop2019), [Bericht](https://www.forschungsdaten.org/index.php/Zweites_Community-Treffen)
-* 27.09.2019 4. Projekttreffen
-* 21.02.2019 3. Projekttreffen
-* 15.11.2018 Workshop über DMPs bei dem Open Science Forum in Luxemburg
-* 21.09.2018 2. Projekttreffen
-* 13.09.2018 Lokaler Workshop in Dresden
-* 03.09.2018 1. Community-Treffen in Uni Duisburg-Essen [Bericht](http://www.forschungsdaten.org/index.php/Erstes_Community-Treffen)
-* 17./18.07.2018 Lokaler Workshop in Bochum und Siegen
-* 12.07.2018 Lokaler Workshop in Darmstadt
-* 11.06.2018 Lokaler Workshop in der UB Braunschweig
-* 20.04.2018 Lokaler Workshop an der RWTH Aachen
-* 08./09.02.2018 1. Projekttreffen
-* 18.10.2017 Lokaler Workshop am Alfred-Wegner-Institut (AWI) in Bremerhaven
-* 17.04.2017 Lokaler Workshop am ZB Med Informationszentrum Lebenswissenschaften
-* 10.08.2017 Lokaler Workshop an der Ruhr Universität Bochum (RUB)
-* 07.04.2017 Abschlussworkshop der ersten Projektphase mit Vorstellung der Projektergebnisse
-* 27.06.2016 Input-Workshop mit ausgewählten Expertinnen und Experten aus der Forschungsdaten-Community
+<details>
+  <summary style="list-style-image: &#9658;"><u>Siehe Liste der Workshops:</u></summary>
+  <ul>
+	<li>04.10.2021 6. RDMO-Community-Treffen (virtuell).
+	[Programm](/events/workshop102021_programm)
+	</li>
+	<li>02.09.2021 DMPs in der NFDI - Kick-Off Meeting</li>
+	<li>02.03.2021 RDMO AG gemeinsam mit NFDI4ING und NFDI-Direktorat
+	[Programm und Slides](/docs/nfdiws/workshop-nfdi)
+	[Bericht](/docs/nfdiws/wsreport)</li>
+	<li>07.10.2020 4. RDMO-Community-Treffen (virtuell)
+	[Programm](/events/workshop102020_programm)
+	[Bericht](https://www.forschungsdaten.org/index.php/Viertes_Community-Treffen)</li>
+	<li>24.02.2020 3. RDMO-Community-Treffen, Gründungstreffen als Open Source Projekt
+	[Programm](/events/workshop022020_programm)
+	[Bericht](https://www.forschungsdaten.org/index.php/Drittes_Community-Treffen)</li>
+	<li>03.12.2019 Lokaler Workshop in Bonn an der Max Weber Stiftung</li>
+	<li>07.10.2019 2. Community-Treffen, ULB Darmstadt
+	[Programm+Slides](/events/workshop2019), [Bericht](https://www.forschungsdaten.org/index.php/Zweites_Community-Treffen)</li>
+	<li>27.09.2019 4. Projekttreffen</li>
+	<li>21.02.2019 3. Projekttreffen</li>
+	<li>15.11.2018 Workshop über DMPs bei dem Open Science Forum in Luxemburg</li>
+	<li>21.09.2018 2. Projekttreffen</li>
+	<li>13.09.2018 Lokaler Workshop in Dresden</li>
+	<li>03.09.2018 1. Community-Treffen, Uni Duisburg-Essen
+	[Bericht](http://www.forschungsdaten.org/index.php/Erstes_Community-Treffen)</li>
+	<li>17./18.07.2018 Lokaler Workshop in Bochum und Siegen</li>
+	<li>12.07.2018 Lokaler Workshop in Darmstadt</li>
+	<li>11.06.2018 Lokaler Workshop in der UB Braunschweig</li>
+	<li>20.04.2018 Lokaler Workshop an der RWTH Aachen</li>
+	<li>08./09.02.2018 1. Projekttreffen</li>
+	<li>18.10.2017 Lokaler Workshop am Alfred-Wegner-Institut (AWI) in Bremerhaven</li>
+	<li>17.04.2017 Lokaler Workshop am ZB Med Informationszentrum Lebenswissenschaften</li>
+	<li>10.08.2017 Lokaler Workshop an der Ruhr Universität Bochum (RUB)</li>
+	<li>07.04.2017 Abschlussworkshop der ersten Projektphase mit Vorstellung der Projektergebnisse</li>
+	<li>27.06.2016 Input-Workshop mit ausgewählten Expertinnen und Experten aus der Forschungsdaten-Community</li>
+  </ul>
+</details>
+
 
 ## Vorträge:
 
 RDMO wurde bereits bei zahlreichen Anlässen vorgestellt und diskutiert:
 
 <details>
-  <summary><u>Siehe Liste der Vorträge:</u></summary>
+  <summary style="list-style-image: &#9658;"><u>Siehe Liste der Vorträge:</u></summary>
   <ul class="talks">
 {% for talk in site.data.talks %}
     <li>
@@ -70,7 +86,7 @@ RDMO wurde bereits bei zahlreichen Anlässen vorgestellt und diskutiert:
         {% endif %}
     </li>
 {% endfor %}
-</ul>
+  </ul>
 </details>
 
 ## Publikationen:
@@ -96,15 +112,29 @@ An der [Fachhochschule Potsdam (FHP)](http://www.fh-potsdam.de/) wird das Projek
 *Michaela Meyer*  
 [Link zur Hausarbeit]({{ site.baseurl }}/docs/Projektarbeit_Meyer_Sozialwissenschaftliche_Fragestellungen_zum_FDM.pdf)
 
+* **Datenmodellierung für Forschungsdatenmanagementpläne**
+*Martin Heger*
+[Link zur Masterarbeit]({{ site.baseurl }}/docs/Heger_MA.pdf)
+(Anmerkung: Durch die Weiterentwicklung von RDMO entsprechen einige der hier beschriebenen Informationen zum [Datenmodells](https://rdmo.readthedocs.io/en/latest/management/domain.html#attributes-entities-and-the-data-model-refactoring) nicht mehr dem aktuellen Stand.)
+
 Es wurde zudem eine umfangreiche Sammlung von [Schriften zum Thema Forschungsdatenmanagement](https://www.zotero.org/groups/forschungsdaten/items) auf Zotero zusammengestellt.
 
-Im Projektkontext hat Martin Heger seine Masterarbeit mit dem Titel "Datenmodellierung für Forschungsdaten-managementpläne" verfasst. [Link zur Masterarbeit]({{ site.baseurl }}/docs/Heger_MA.pdf)
-(Anmerkung: Durch die Weiterentwicklung von RDMO entsprechen einige der hier beschriebenen Informationen zum [Datenmodells](https://rdmo.readthedocs.io/en/latest/management/domain.html#attributes-entities-and-the-data-model-refactoring) nicht mehr dem aktuellen Stand.)
 
 ## Bekanntmachungen:
 
 <details>
-  <summary>**Dezember 2021**</summary>
+	<summary><b></b></summary>
+</details>
+
+<details>
+	<summary><b>Februar 2022</b></summary>
+	Auf Vorschlag der Software-Gruppe hat das Steuerungsgremium eine Restrukturierung der RDMO Git-Repositorien und der Personen bzw. Gruppen vorgenommen, die die Bearbeitung der Repositorien regeln. Dabei wurden vor allem die neuen Strukturen der RDMO-Arbeitsgemeinschaft reflektiert.
+	<br/>
+	In der NFDI hat sich eine Task Force „DMPs in der NFDI“ innerhalb der NFDI Tools Gruppe formiert. Mitglieder der NFDI-beteiligten Konsortien (/Institute)  können sich über die folgende URL für die Mailing-Liste anmelden: https://lists.nfdi.de/postorius/lists/dmpsindernfdi.lists.nfdi.de
+</details>
+
+<details>
+  <summary style="list-style-image: &#9658;"><b>Dezember 2021</b></summary>
 Ab sofort ist die neue Version RDMO 1.7.0 verfügbar. Es handelt sich zwar primär um Fehlerbehebungen, da jedoch zusätzliche Funktionalität hinzugekommen ist, wird die mittlere Zahl der Versionsnummer erhöht. Als Reaktion auf Feedback haben wir das Interview leicht überarbeitet. Bei den Fragen zu Datensätzen wird jetzt mit “Sichern und fortfahren” nicht mehr zum nächsten Datensatz gewechselt, sondern zum nächsten Fragenset, wobei aber der gleiche Datensatz weiterbearbeitet wird. (Über die Einstellung PROJECT_QUESTIONS_CYCLE_SETS kann das alte Verhalten behalten werden.) Fragensets, die durch Bedingungen übersprungen werden können, werden durch ein kleines Fragezeichen in der Navigation gekennzeichnet. Mehr Informationen gibt es wie immer auf der Release-Seite: https://github.com/rdmorganiser/rdmo/releases
 
 Außerdem stehen einige Neuerungen im Repositorium rdmo-catalog an. Sie werden unter der Versionsnummer 1.1.0-rdmo-1.6.0 veröffentlicht, wobei rdmo-1.6.0 bedeutet, dass das Release mit RDMO ab 1.6.0 verwendet werden kann. Es sind folgende Änderungen enthalten:
@@ -117,8 +147,8 @@ Außerdem stehen einige Neuerungen im Repositorium rdmo-catalog an. Sie werden u
 </details>
 
 <details>
-  <summary>**November 2021**</summary>
-in den letzten Wochen sind einige kleinere Probleme in RDMO aufgefallen, weshalb ab sofort die Version 1.6.2 verfügbar ist, die im wesentlichen Bug Fixes enthält. So wurden Overlays repariert für den Fall, dass in den Einstellungen PROJECT_ISSUES deaktiviert waren. Außerdem wurde ein Fehler behoben, der aufgetreten ist, wenn Datensätze entfernt werden. Ein Problem beim Auflösen von Bedingungen in Fragensets wurde ebenfalls beseitigt. Einige Verbesserungen, die eher für technische Interessierte oder RDMO-Administrierende interessant sein dürften, sind ebenfalls auf der Liste der Neuerungen. Von nun an nutzen wir Github-Actions und nicht mehr Travis-CI für unsere automatischen Tests. Weiterhin wurde auf der Kommandozeile ein Befehl hinzugefügt, mit dem sich Projekte aufspüren und entfernen lassen, die beispielsweise keine Besitzer haben. Unsere Release Notes finden sich wie immer hier: https://github.com/rdmorganiser/rdmo/releases.
+  <summary><b>November 2021</b></summary>
+In den letzten Wochen sind einige kleinere Probleme in RDMO aufgefallen, weshalb ab sofort die Version 1.6.2 verfügbar ist, die im wesentlichen Bug Fixes enthält. So wurden Overlays repariert für den Fall, dass in den Einstellungen PROJECT_ISSUES deaktiviert waren. Außerdem wurde ein Fehler behoben, der aufgetreten ist, wenn Datensätze entfernt werden. Ein Problem beim Auflösen von Bedingungen in Fragensets wurde ebenfalls beseitigt. Einige Verbesserungen, die eher für technische Interessierte oder RDMO-Administrierende interessant sein dürften, sind ebenfalls auf der Liste der Neuerungen. Von nun an nutzen wir Github-Actions und nicht mehr Travis-CI für unsere automatischen Tests. Weiterhin wurde auf der Kommandozeile ein Befehl hinzugefügt, mit dem sich Projekte aufspüren und entfernen lassen, die beispielsweise keine Besitzer haben. Unsere Release Notes finden sich wie immer hier: https://github.com/rdmorganiser/rdmo/releases.
 
 Die Berichte zum Community-Treffen vom 04.10.2021 sind - wie immer - auf
 https://www.forschungsdaten.org/index.php/Sechstes_Community-Treffen zu finden.
@@ -127,7 +157,7 @@ Am 16. November war der Tag der Forschungsdaten in NRW. Im Nachmittagsprogramm h
 </details>
 
 <details>
-  <summary>**Oktober 2021**</summary>
+  <summary><b>Oktober 2021</b></summary>
 Nach einer 2 monatigen Testphase haben wir am Dienstag RDMO 1.6 veröffentlicht. Wie immer finden Sie die relevanten Informationen auf der Release-Page auf GitHub:
 
     https://github.com/rdmorganiser/rdmo/releases/tag/1.6
@@ -148,7 +178,7 @@ RDMO nutzt ab Version 1.6 Django 3.2 und setzt damit Python 3.6 voraus. Wenn das
 </details>
 
 <details>
-  <summary>**September 2021**</summary>
+  <summary><b>September 2021</b></summary>
 Community-Workshop am 4. Oktober 2021:
 
 Die das ausführliche [Programm](https://rdmorganiser.github.io/events/workshop102021_programm/) ist jetzt veröffentlicht. Wir werden noch die Beiträge für die Breakout-Sessions in der letzten September-Woche hinzufügen.
@@ -165,22 +195,22 @@ Die Testphase läuft noch mindestens bis zum nächsten Entwicklertreffen, welche
 </details>
 
 <details>
-  <summary>**August 2021**</summary>
+  <summary><b>August 2021</b></summary>
 Auch im Sommer geht es fleißig mit RDMO weiter! Die neue neuen Version von RDMO ist jetzt soweit, dass wie angekündigt, eine Testphase beginnen kann. Der Release Candidate muss direkt von GitHub installiert werden, wie das geht, steht auf der [(pre-)Release-Page](https://github.com/rdmorganiser/rdmo/releases/tag/1.6-rc.1). Außerdem ist die Liste zahlreicher Änderungen auf dieser Seite einsehbar.
 </details>
 
 <details>
-  <summary>**Juli 2021**</summary>
+  <summary><b>Juli 2021</b></summary>
 Die Arbeiten am neuen Release von RDMO, der voraussichtlich Anfang August erscheinen wird, laufen. Teil des Releases werden geschachtelte Fragensets, optionale Fragen, voreingestellte Standardantworten, ein Autocomplete-Widget, Tooltips in Hilfetexten, Tutorial-Einblendungen für neue Benutzerinnen und Benutzer und zahlreiche weitere Verbesserungen sein. Anders als zuvor werden wir vor dem Release eine Testphase legen, in der die neue Version schon mal auf Testinstanzen (sofern vorhanden) ausprobiert werden kann. Wir werden Sie dazu per Mail informieren, wenn es soweit ist.
 </details>
 
 <details>
-  <summary>**April 2021**</summary>
+  <summary><b>April 2021</b></summary>
 RDMO 1.5.5,  eine neue Version, ist veröffentlicht, die wieder ein paar kleinere Bugs beseitigt. Die Version kann wie üblich installiert werden. Wenn bereits RDMO 1.5 installiert ist, müssen auch keine Datenbank-Migrationen durchgeführt werden. Mehr Infos gibt es auf [Release-Seite  auf GitHub](https://github.com/rdmorganiser/rdmo/releases/tag/1.5.5)
 </details>
 
 <details>
-  <summary>**März 2021**</summary>
+  <summary><b>März 2021</b></summary>
 *RDMO 1.5*
 
 In der letzten Woche ist die Version 1.5 von RDMO erschienen, die wieder eine Reihe von Neuerungen enthält. Diesesmal stand besonders die praktische Nutzbarkeit für die Forschenden im Vordergrund. Das Interview wird jetzt immer auf der Seite fortgesetzt, die zuletzt aufgerufen wurde. Am User-Interface wurden einige Details verändert, so dass die Nutzerführung deutlich intuitiver wird. In den Fragenkatalogen können File-Uploads konfiguriert werden, um zusätzliches Material wie Grafiken oder Dokumente hochzuladen. Projekte können nun als Unterprojekte von bestehenden Projekten erstellt werden, wobei sich die Zugriffsrechte vererben. Ansichten von Oberprojekten können auf Unterprojekte zugreifen, um Informationen aus mehreren Projekten zusammenzutragen. Das Hinzufügen von neuen Usern zu Projekten funktioniert jetzt über Email-Benachrichtigungen und es können auch Nutzende, die noch nicht in der RDMO Instanz registriert sind, über diesen Weg eingeladen werden. Auch “unter der Haube” habe wir an RDMO gearbeitet: Durch Optimierung der Datenbankzugriffe sollte RDMO jetzt deutlich schneller und flüssiger sein. Die (eher technische) Übersicht über die einzelnen Features gibt es auf der [Release-Seite auf GitHub](https://github.com/rdmorganiser/rdmo/releases/tag/1.5).
@@ -195,7 +225,7 @@ Am 02.03. führte die Steuerungsgruppe der Arbeitsgemeinschaft RDMO gemeinsam mi
 </details>
 
 <details>
-  <summary>**Februar 2021**</summary>
+  <summary><b>Februar 2021</b></summary>
 Die Arbeiten an einer neuen RDMO-Version, deren Release Ende Februar angestrebt wird,  laufen. Wenn alles klappt wird sie Verbesserungen der Nutzeroberfläche enthalten, es ermöglichen Dateien beim Beantworten von Fragen hochzuladen und eine hierarchische Struktur von Projekten einführen, die dann auf diese Weise verschachtelt werden können. Bis es so weit ist, muss allerdings noch etwas getestet und entwickelt werden.
 
 Wie bereits an anderer Stelle angekündigt veranstaltet die UAG Datenmanagementpläne der DINI/nestor-AG Forschungsdaten in Kooperation mit fdm.nrw im Frühjahr 2021 eine virtuelle Workshopreihe zum Thema Datenmanagementpläne. Eine Beschreibung der Workshops sowie die Anmeldung sind nun online.
@@ -206,14 +236,14 @@ Die Steuerungsgruppe von  RDMO hat gemeinsam mit dem NFDI Direktorat und dem Kon
 </details>
 
 <details>
-  <summary>**Dezember 2020**</summary>
+  <summary><b>Dezember 2020</b></summary>
 Virtuelle RDMO-Sprechstunde
 
 Wir wünschen allen ein erholsames Jahresende und einen Gutes Neues Jahr
 </details>
 
 <details>
-  <summary>**November 2020**</summary>
+  <summary><b>November 2020</b></summary>
 
 Regelmäßige virtuelle Treffen der Content-Gruppe und der Software-Gruppe
 
@@ -225,7 +255,7 @@ Unser 4. Community-Treffen hat am 07.10.2020 virtuell mit ca. 60 Teilnehmerinnen
 </details>
 
 <details>
-  <summary>**Oktober 2020**</summary>
+  <summary><b>Oktober 2020</b></summary>
 Zunächst wollen wir vor allem noch einmal auf das geplante virtuelle RDMO Anwender-Treffen am 07.10.2020 hinweisen. Ein detailliertes [Programm](/events/workshop022020_programm/) ist auf der RDMO-Webseite veröffentlicht. Die Keynote wird von Herrn Sure-Vetter (NFDI-Direktor) gehalten. Außerdem wird das RDMO Memorandum of Understanding (MoU) ausführlich vorgestellt. Bitte melden Sie sich bis zum 04.10.2020 für das Anwender-Treffen auf der [Registrierungsseite](https://meetings.aip.de/event/9/) an.
 
 In der kommenden Woche wird noch vor dem Anwender-Treffen das RDMO-Release 1.3 erscheinen. Es wird einige Neuerungen enthalten, von denen hier nur ausschnittsweise ein paar genannt werden sollen. So wird es neben einigen Bug-Fixes kleinere Verbesserungen an der Nutzeroberfläche, eine erweiterte Konfigurierbarkeit von Referenz-Dokumenten und Erleichterungen beim Anpassen des Footers. Außerdem ist RDMO dank der Arbeit von Dario Pilori und Giacomo Lanza mit dem nächsten Release auch in italienischer Sprache nutzbar. Eine der größeren Veränderungen betrifft die Überarbeitung von Tasks, die in ihrer Funktionalität deutlich erweitert wurden.
@@ -233,7 +263,7 @@ In der kommenden Woche wird noch vor dem Anwender-Treffen das RDMO-Release 1.3 e
 </details>
 
 <details>
-  <summary>**September 2020**</summary>
+  <summary><b>September 2020</b></summary>
 Auch in diesem Monat waren wir nicht untätig und haben heute Version 1.2 von RDMO veröffentlicht. In den Management-Oberflächen können nun Elemente wie Optionen, Attribute, aber auch ganze Fragenkataloge direkt kopiert werden. Kataloge, Aufgaben und Ansichten können von den Nutzenden verborgen werde (z.B. so lange noch an ihnen gearbeitet wird). Attribute und Bedingungen zeigen an, in welchen Fragen, Fragensets, etc. sie genutzt werden. Elemente können jetzt auch einzeln exportiert werden, z.B. ein Fragenset oder eine Ansicht. Auch den Import haben wir neu gestaltet. Vor dem eigentlichen Import wird jetzt angezeigt was importiert wird und ob es Probleme dabei gibt. Außerdem können einzelne Elemente abgewählt werden. Nach dem Import wird noch einmal gezeigt was importiert wurde und ob es Fehler gegeben hat.
 
 Auch einige Fehler wurden mit dem neuen Release behoben. Viele von ihnen betrafen Übersetzungen. RDMO ist nun besser auf fehlende Texte vorbereitet, sollten diese in der gewählten Sprache nicht verfügbar sein. In diesen Fällen wird auf die vorhandene Sprache zurückgegriffen. Views wurden um vier verfügbare Variablen erweitert. Die Funktion “render_value” kann nun mit “project/title”, “project/description”, “project/created” und “project/updated” verwendet werden.
@@ -242,7 +272,7 @@ Auch einige Fehler wurden mit dem neuen Release behoben. Viele von ihnen betrafe
 </details>
 
 <details>
-  <summary>**August 2020**</summary>
+  <summary><b>August 2020</b></summary>
 In der neuen RDMO-Version 1.1 haben wir die Projekt Export- und Import-Funktionalitäten überarbeitet. Damit sind die Grundlagen gelegt, Formate wie DataCite, das von DataCite abgeleitete Schema von RADAR und auch das von der RDA vorgeschlagene [maDMP](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard) in RDMO zu unterstützen. Da das Mapping von RDMO auf diese Formate aber abhängig von unserem Domänenmodell ist, das aber wiederum kein Teil des RDMO-Codes ist, sondern unabhängig gepflegt wird, war es nötig den Code hierfür in Plugins auszulagern. Diese werden in der Zukunft, analog zu dem [rdmo-catalog](https://github.com/rdmorganiser/rdmo-catalog) Repository, in [rdmo-plugins](https://github.com/rdmorganiser/rdmo-plugins) gesammelt. Das “Mapping” der Formate auf das RDMO Domänenmodell passiert im Code dieser Plugins, wurde von uns aber zusätzlich in einem [Google-Doc](https://docs.google.com/spreadsheets/d/16fQ0Rgg-2ewMK9FklEjU8pAcpHODEm7PYy6xDCninew/edit?usp=sharing) dokumentiert. Für die vollständige Unterstützung wird es aber noch nötig sein, zusätzliche Fragen und Attribute einzuführen.
 
 In der Zukunft wollen wir diese Art von Plugins verstärkt nutzen, um Domänenspezifische Features in RDMO zu realisieren und natürlich können Plugins auch von Instanzen genutzt werden, um stärker angepasste Funktionalitäten zu realisieren. Die Details gibt es in der [Plugin Dokumentation](https://rdmo.readthedocs.io/en/latest/plugins/index.html).
@@ -250,123 +280,123 @@ In der Zukunft wollen wir diese Art von Plugins verstärkt nutzen, um Domänensp
 </details>
 
 <details>
-  <summary>**Juli 2020**</summary>
+  <summary><b>Juli 2020</b></summary>
 Die neue Version 1.0.7 von RDMO beinhaltet als Neuerungen 1) Multi-Site-Setup: Betreiben verschiedener RDMO-Seiten mit unterschiedlichen URLs und Themes auf einem Server mit einer gemeinsamen Datenbank (mehr unter [https://rdmo.readthedocs.io/en/latest/configuration/multisite.html](https://rdmo.readthedocs.io/en/latest/configuration/multisite.html)); 2) Bestimmte User können jetzt über das Admin-Interface zu Site-Managern gemacht werden (mehr unter [https://rdmo.readthedocs.io/en/latest/administration/users.html#roles](https://rdmo.readthedocs.io/en/latest/administration/users.html#roles)); 3) RDMO steht ab sofort in französischer Sprache zu Verfügung (Texte in der Software selbst, RDMO-Fragenkatalog sowie die ihm anhängigen Optionen und einige andere Bezeichner und Hilfetexte), die entsprechenden XML-Dateien stehen über das Catalog-Repository zur Verfügung;  4) die Nutzungsbedingungen sind nun über eine eigene URL verfügbar. Außerdem ist sind die Aufzeichnung und Folien der Präsentation des RDMO-Teams “Datenmanagementpläne mit RDMO” für das Projekt FDM-BB nun verfügbar unter: [https://mediaup.uni-potsdam.de/Play/19500](https://mediaup.uni-potsdam.de/Play/19500).
 
 </details>
 
 <details>
-  <summary>**Juni 2020**</summary>
+  <summary><b>Juni 2020</b></summary>
 Im Mai haben wir die erste virtuelle RDMO-Sprechstunde durchgeführt. Aus dem Gespräch ergab sich die Bitte, Bedarfe möglichst als GitHub-Issues, als dauerhaftesten und am besten nachvollziehbaren Workflow anzulegen. Für Fragen zum Anlegen von Issues kontaktieren Sie uns am besten im RDMO-Slack oder über Email. Das RDMO-Team hat vom 27.-28.05.2020 am [virtuellen “RDA Hackathon on maDMP”](https://rda-dmp-common.github.io/hackathon-2020/) teilgenommen und an der Interoperabilität von RDMO mit dem [maDMP Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard) gearbeitet. Das Ergebnis ist ein Plugin, in dem das Mapping stattfindet und ein Export zum maDMP JSON-Format erstellt wird. Außerdem präsentierte das RDMO-Team “Datenmanagementpläne mit RDMO” am 08.06.2020 in einem vom Projekt FDM-BB (Universität Potsdam, Fachhochschule Potsdam) organisierten Webinar.
 
 </details>
 
 <details>
-  <summary>**Mai 2020**</summary>
+  <summary><b>Mai 2020</b></summary>
 RDMO ist nun in Version 1.0.6 verfügbar. Mit der neuen Version ist es möglich, in Ansichten einfache mathematische Berechnungen durchzuführen z. B. für einfache tabellarische Zusammenfassung der anfallenden Personal- und Sachkosten. Nähere Erläuterungen im [Tutorial](https://www.forschungsdaten.org/index.php/Ansicht_erstellen) und in der [technischen Dokumentation](https://rdmo.readthedocs.io/en/latest/management/views.html). Seit Mai gibt es jeden ersten Donnerstag des Monats (außer an Feiertagen) für Mitglieder der RDMO-Community (DatenmanagerInnen, AdministratorInnen etc.) eine “virtuelle RDMO-Sprechstunde”. Details im [RDMO-Newsletter](https://www.listserv.dfn.de/sympa/info/rdmo). Außerdem hat die Steuerungsgruppe beschlossen, dass RDMO als Open Source Projekt ab sofort RDMO Arbeitsgemeinschaft heißt und bereitet ein Memorandum of Understanding vor, auf dessen Grundlage die Beteiligung an der Weiterführung von RDMO von Institutionen und Organisationen erfolgen wird. Die Mitglieder der Gruppen der Arbeitsgemeinschaft sind unter [https://rdmorganiser.github.io/groups/](/groups/) zu finden.
 
 </details>
 
 <details>
-  <summary>**April 2020**</summary>
+  <summary><b>April 2020</b></summary>
 RDMO Release 1.0.5 (Bug Fixes, u. a. Login mit ORCID, Fehler beim Download der Vendor Files, Darstellung von Sets in Views). Ein Update ist empfohlen. Siehe die Dokumentation bzgl. der für die ORCID notwendigen neuen Einträge in der local.py. Der Bericht des 3. RDMO-Anwendertreffens ist [online](https://www.forschungsdaten.org/index.php/Drittes_Community-Treffen). Ab Mai 2020 gibt es eine “virtuelle RDMO Sprechstunde”, bitte [kontaktieren](https://rdmorganiser.github.io/) Sie uns für Details. Wir haben den [“DFG-Fragenkatalog” vom Projekt FoDaKo, Bergische Universität Wuppertal (Torsten Rathmann) (CC0)](https://github.com/rdmorganiser/rdmo-catalog/tree/master/shared/fodako) in die AIP-Demo-Instanz eingepflegt und nehmen weiterhin Kataloge aus der Community in das GitHub Repository auf: entweder einen Pull-Request auf GitHub erstellen oder die XML-Dateien per Mail an omichaelis@aip.de senden. Besonders hilfreich für die Nachnutzung sind die zusätzliche Bereitstellung einer Read.me-Datei bzw. Dokumentation zum jeweiligen Katalog.
 
 </details>
 
 <details>
-  <summary>**März 2020**</summary>
+  <summary><b>März 2020</b></summary>
 Im Februar fand das dritte RDMO-Anwendertreffen statt. Es war fokussiert auf die Etablierung einer Governance-Struktur für die Weiterführung von RDMO, unabhängig von dem in diesem Jahr endenden DFG-Projekt, das die Grundlage für RDMO geschaffen hat. Ein Block von Kurzvorträgen, die den Kontext im europäischen (Horizon Europe) und nationalen Raum (NFDI) skizzierten, wie auch einige Weiterentwicklungsaspekte von RDMO, reflektierte die gegenwärtige Situation. [Vorträge und Programm](/events/workshop022020_programm/). Das vom Projekt vorgelegte Manifest und weitere Beiträge haben in der Etablierung einer Steuerungsgruppe mit  6+ Personen, einer  Softwaregruppe mit 3+ Personen sowie einer Content-Gruppe mit 6+ Personen resultiert. Die Steuerungsgruppe wurde damit beauftragt, die Governance-Struktur weiter auszuarbeiten und ein MoU für RDMO auszuarbeiten, um den formalen Rahmen für RDMO zu festigen. Weitere Schritte werden über die Website und Mails bekannt gemacht. Während der [RDA-De-Tagung](https://www.rda-deutschland.de/events/tagung-2020) haben Olaf Michaelis und Ulrike Wuttke am Vormittag des 25.02.2020 im Rahmen des Project-Tracks einen RDMO-Workshop angeboten. Während des gut besuchten Workshops, in dem die wichtigsten Features und weitere Entwicklungsmöglichkeiten des Werkzeugs vorgestellt wurden, und im weiteren Verlauf der Konferenz freuten wir uns über intensiven Austausch zu RDMO. Das starke Interesse an RDMO in der deutschen Community wurde insbesondere aus den Präsentationen der Bundesland-FDM-Initiativen deutlich.
 
 </details>
 
 <details>
-  <summary>**Februar 2020**</summary>
+  <summary><b>Februar 2020</b></summary>
 Diesen Monat gab es [RDMO-Release 1.0.3.](https://github.com/rdmorganiser/rdmo/releases/tag/1.0.3) Es enthält einige Verbesserungen und behebt kleinere Fehler. Es stehen neue API-Filter-Attribute zur Verfügung, die Schnittstellen flexibler machen. Sie werden es unter anderem erleichtern, einen Satz an Antworten zu exportieren und diesem anschließend die entsprechenden Fragen zuzuordnen, da Fragen nun beispielsweise mit dem Parameter “attribute” über die API lokalisiert werden können. Außerdem nutzt RDMO nun “pytest”, mit dem auch die [RDMO-App getestet werden kann](https://github.com/rdmorganiser/rdmo/blob/master/docs/testing.md). Im Januar war RDMO beim [Workshop der DHd-AG Datenzentren am 23./24.01.2020 in Frankfurt an Main](http://dig-hum.de/aktuelles/einladung-zum-workshop-der-dhd-ag-datenzentren-zum-thema-interoperabilit%C3%A4t-am-2324012020) vertreten. Ulrike Wuttke und Olaf Michaelis haben die bisher im Projekt erfolgten Anstrengungen vorgestellt, RDMO Datacite kompatibel zu machen. Der Beitrag “Vom Projekt zum nachhaltigen Werkzeug für das Forschungsdatenmanagement: Das Beispiel Research Data Management Organiser” wurde zum [109. Deutschen Bibliothekartag](https://bibliothekartag2020.de) (26. - 29. Mai 2020, Hannover) angenommen.
 
 </details>
 
 <details>
-  <summary>**Januar 2020**</summary>
+  <summary><b>Januar 2020</b></summary>
 Im Mittelpunkt des inzwischen 3. RDMO-Community-Treffens am 24.02.2020 am Leibniz-Institut für Astrophysik Potsdam (AIP) werden die Verabschiedung des [RDMO-Manifests](/docs/RDMO-Manifest-122019.pdf) und die Gründung der RDMO Community, insbesondere die Konstituierung der *Steuerungsgruppe* und der *Software-Gruppe* stehen. Außerdem sind wieder kurze *Spotlights* aus der Community der RDMO-Anwender\*innen vorgesehen. Link zum [Programm](/events/workshop022020_programm/). Während der an das Community-Treffen anschließenden [RDA-De-Tagung](https://www.rda-deutschland.de/events/tagung-2020) werden wir am Vormittag des 25.02.2020 einen RDMO-Workshop anbieten. Die Registrierung ist inzwischen möglich.
 
 </details>
 
 <details>
-  <summary>**November 2019**</summary>
+  <summary><b>November 2019</b></summary>
 Diesen Monat haben wir einige Aktualisierungen und Umgestaltungen an den RDMO-Schulungsmaterialien vorgenommen. Sie finden Schulungsmaterialien wie Video-Tutorials oder den RDMO-Fragenkatalog auf der RDMO-Webseite unter [Dokumentation](/dokumentation/). Weitere Tutorials, FAQs etc. für verschiedene Zielgruppen (Administrator*innen, Nutzer*innen) finden Sie auf dem Wiki [forschungsdaten.org](https://www.forschungsdaten.org/index.php/RDMO). Das 3. Anwendertreffen wird am 24.02.2020 in Potsdam am AIP stattfinden. Dort ist die Konstituierung der künftigen Organisation von RDMO geplant.
 
 </details>
 
 <details>
-  <summary>**Oktober 2019**</summary>
+  <summary><b>Oktober 2019</b></summary>
 RDMO hat den Sprung auf Version 1 gemacht. Die neueste Version enthält zwei wichtige Neuerungen, die die Projektzugehörigkeit von Nutzern betreffen. Zum einen kann diese nun über die API gesteuert werden und zum anderen können Nutzer sich nun selbst jederzeit aus einem Projekt entfernen, wenn sie nicht der letzte Besitzer dieses Projektes sind. Der Bericht vom 2. RDMO-Anwendertreffen am 07.10.2019 in Darmstadt an der ULB ist [online](https://www.forschungsdaten.org/index.php/Zweites_Community-Treffen). Außerdem haben wir RDMO bei den Open Access Tagen in Hannover präsentiert sowie die Schulungsmaterialien zu RDMO bei einem Workshop in Hildesheim ([Folien online auf Zenodo](http://doi.org/10.5281/zenodo.3520839)).  
 
 </details>
 
 <details>
-  <summary>**September 2019**</summary>
+  <summary><b>September 2019</b></summary>
 Am 27.09.2019 fand in Berlin das halbjährliche Treffen des RDMO-Projekts statt. Es gab intensive Diskussionen zum Thema Nachhaltigkeit und zur weiteren Entwicklung von RDMO. Außerdem wurden die letzten Details für das nächste RDMO-Anwendertreffen in Darmstadt geklärt.
 
 </details>
 
 <details>
-  <summary>**August 2019**</summary>
+  <summary><b>August 2019</b></summary>
 Das diesjährige [**RDMO-Anwendertreffen** findet am 07.10.2019 an der ULB Darmstadt](/events/workshop2019/) statt. Studenten “Data Stewardship” der TU Wien haben einige Prototypen, Mappings und Beispiele entwickelt mit Hinsicht auf den Export von machine-actionable Data Management Plans aus einer RDMO-Instanz nach dem [**RDA-Standard für maDMPs**](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard). Mehr Informationen finden sich [hier](https://helmuthb.github.io/dmp-tools-actionable/). Diese Entwicklungen stehen im Kontext zu Bestrebungen des RDMO-Projekts, mit RDMO erstellte DMPs mit dem maDMP-Standard interoperabel zu machen. Außerdem ist die neue [**RDMO-Version 0.14.6**](https://github.com/rdmorganiser/rdmo/releases/tag/0.14.6) verfügbar (kleine Änderungen, Bugfix).
 
 </details>
 
 <details>
-  <summary>**Juli 2019**</summary>
+  <summary><b>Juli 2019</b></summary>
 Im letzten Monat haben wir ein paar kleinere Bugs in RDMO gefunden und beseitigt. Insbesondere hat der Installationsvorgang durch ein Update bei einer von uns verwendeten Bibliothek nicht mehr funktioniert. Die Änderungen sind in der [**neuen Version 0.14.5** auf Github](https://github.com/rdmorganiser/rdmo/releases/tag/0.14.5) enthalten, die wie üblich installiert werden kann.
 
 </details>
 
 <details>
-  <summary>**Juni 2019**</summary>
+  <summary><b>Juni 2019</b></summary>
 Wir haben den **DCC-Fragenkatalog**, dessen Import nicht korrekt funktionierte, repariert. Die aktualisierte Version ist auf GitHub. Er enthält zehn neue Attribute, die dem Domänenmodell hinzugefügt wurden. Daher sollte vor dem Einlesen des Katalogs erst das Domänenmodell importiert werden. Der Import der aktuellen XML-Datei kann ohne vorbereitende Schritte erfolgen. Bereits importierte Daten bleiben erhalten und werden lediglich um die fehlenden zehn Einträge ergänzt. Außerdem gibt es nun eine **weitere Methode, RDMO zu installieren oder auch schnell auszuprobieren**. Auf GitHub befindet sich eine Version RDMOs, die in Docker Compose verpackt ist. Wir würden uns über weitere Anregungen freuen, um auch diesen RDMO-Installationsweg weiter zu verbessern. Mit Beginn des Monats Juli wird Olaf Michaelis bis Anfang Oktober in Elternzeit gehen. RDMO wird in den drei Monaten seiner Abwesenheit natürlich trotzdem weiter betreut und entwickelt, wenn auch mit etwas weniger Personal.
 
 </details>
 
 <details>
-  <summary>**Mai 2019**</summary>
+  <summary><b>Mai 2019</b></summary>
 RDMO **Version 0.14.4** (Bug Fixes) ist verfügbar. Probleme, die durch die Umstellung auf Django2 und Python3 verursacht wurden, sollten nun beseitigt sein. Ein Update wird wärmstens empfohlen, da Python2 nicht mehr lange unterstützt wird. Im Mai hat der Kick-Off des Projekts [**»Management Molekularer Daten im Research Data Life Cycle« (MaMoDaR)**](https://www.fh-potsdam.de/informieren/aktuelles/news-detailansicht/artikel/start-fuer-forschungsprojekt-mamodar/), eine Kooperation der FH Potsdam und des Robert Koch-Instituts, an der FHP stattgefunden und das **IPK Gatersleben** hat RDMO als Forschungsdatenmanagement-Werkzeug aus der Testphase in die Anwendungsphase überführt. Falls Sie **FDM-Schulungen mit dem Einsatz von RDMO** planen, teilen Sie uns die Termine mit, dann können wir sie mitbewerben (z. B. Twitter, Newsletter) und teilen Sie uns auch gerne Ihr Feedback und Erfahrungsberichten aus den Schulungen bzw. Schulungsmaterialien mit.
 
 </details>
 
 <details>
-  <summary>**April 2019**</summary>
+  <summary><b>April 2019</b></summary>
 Die neue **Version 0.14** ist veröffentlicht. Die größten Neuerungen sind die Umstellung auf Django 2.2 und Python 3 (ab dieser Version funktioniert RDMO mit Python 2 nicht mehr!) und die Überarbeitung der API und Erweiterung auf Schreibzugriffe. Ab Django 2.1 werden ältere Versionen von MySQL und PostgreSQL nicht mehr unterstützt. Bitte schauen Sie vor dem Update in die [Django release notes](https://docs.djangoproject.com/en/2.2/releases/2.1/) um Überraschungen zu vermeiden. Außerdem soll eine **Plattform für den Austausch von Fragenkatalogen** geschaffen werden. Sie können uns Fragenkataloge, die Sie gerne teilen möchten, zukommen lassen.
 
 </details>
 
 <details>
-  <summary>**März 2019**</summary>
+  <summary><b>März 2019</b></summary>
 Die neue RDMO-Version 0.13 ist veröffentlicht. Die größte Neuerung ist die Überarbeitung der Mehrsprachigkeit. RDMO lässt sich jetzt mit bis zu 5 Sprachen verwenden. Auch eine Instanz nur auf Englisch ist möglich. RDMO war diesen Monat auf zwei Veranstaltungen vertreten: beim 7. Bibliothekskongress 2019 (Leipzig) mit einem RDMO Hands-On Lab und den eScience-Tagen 2019 in Heidelberg mit einem Poster, einem Demotisch und einem Lightning Talk.
 
 </details>
 
 <details>
-  <summary>**Februar 2019**</summary>
+  <summary><b>Februar 2019</b></summary>
 Im Februar fand das reguläre Treffen der RDMO-Projektgruppe in Berlin statt. Es gab intensive Diskussionen zur Nachhaltigkeit. Es wurde beschlossen, am 07.10.2019 ein RDMO-Anwendertreffen an der ULB Darmstadt zu organisieren. Auf der **RDA Deutschland Tagung** war das RDMO-Projekt mit einem [Poster](https://www.rda-deutschland.de/events/rda-deutschland-tagung-2019-poster) vertreten.
 
 </details>
 
 <details>
-  <summary>**Januar 2019**</summary>
+  <summary><b>Januar 2019</b></summary>
 
 Wir veröffentlichen **Version 0.12.0** von RDMO mit verbessertem Fehlermanagament, einer Schaltfläche für den URI Präfix und der Möglichkeit Nutzerprofile zu löschen. Es wurden zwei neue **[Screencasts](/materialien/)** veröffentlicht. Wir sammeln *Fragenkataloge und Ansichten* ein. *Janine Straka* vom RMDO-Team geht ab Februar in Mutterschutz und anschließend in die Elternzeit. Die Vertretung übernimmt ab März *Ulrike Wuttke*.
 
 </details>
 
 <details>
-  <summary>**Dezember 2018**</summary>
+  <summary><b>Dezember 2018</b></summary>
 
 Es steht nun fest, dass *Jochen Klar* das AIP verlassen wird, aber auch zukünftig eng mit dem RDMO-Team zusammenarbeiten wird. Weitere Screencasts sind in Arbeit.
 
 </details>
 
 <details>
-  <summary>**November 2018**</summary>
+  <summary><b>November 2018</b></summary>
 
 Wir veröffentlichen **Version 0.11.0** von RDMO mit dem neuen *Datenmodell*. Mit dem neuen Aufbau wird es möglich sein, unkompliziert eigene Fragenkataloge zu erstellen und gleichzeitig das Domänenmodell der ganzen RDMO Community zu nutzen, um Ansichten, Fragenkataloge, etc. nachzunutzen. Wir haben auch unsere Dokumentation überarbeitet und um die neuen Arbeitsschritte ergänzt.
 
@@ -378,7 +408,7 @@ Wir haben außerdem einen ersten **[Screencast](/materialien/)** auf unserer Web
 </details>
 
 <details>
-  <summary>**Oktober 2018**</summary>
+  <summary><b>Oktober 2018</b></summary>
 
 Am 24.10. präsentierten wir ein RDMO-Poster bei der **[International Open Access Week 2018](http://www.open-access-berlin.de/aktivitaeten)** in Berlin.
 Außerdem haben wir unsere **Werbepostkarte** überarbeitet und es gibt jetzt auch eine englische [Version](/en/promotion/).
@@ -387,7 +417,7 @@ Außerdem haben wir unsere **Werbepostkarte** überarbeitet und es gibt jetzt au
 </details>
 
 <details>
-  <summary>**September 2018**</summary>
+  <summary><b>September 2018</b></summary>
 
 Anfang September fand unser erstes, großes Community-Treffen an der Universität Duisburg-Essen mit regem Austausch statt. Hier gibt es einen Bericht: http://www.forschungsdaten.org/index.php/Erstes_Community-Treffen Mitte September hatten wir einen lokalen Workshop an der SLUB Dresden veranstaltet, wo RDMO noch recht neu ist. Ende September fand unser zweites Projekttreffen der zweiten Projektphase in Karlsruhe statt.
 Für die Weiterentwicklung von RDMO haben wir einen Fahrplan für die nächsten großen Features festgelegt:
@@ -409,14 +439,14 @@ Für die Weiterentwicklung von RDMO haben wir einen Fahrplan für die nächsten 
 </details>
 
 <details>
-  <summary>**August 2018**</summary>
+  <summary><b>August 2018</b></summary>
 
 Im August haben wir die letzten Vorkehrungen für unser erstes, großes **Community-Treffen** getroffen, welches in der Universität Duisburg-Essen statt finden wird. Wir haben auch auf Anfrage einen aktuellen **[Foliensatz](/materialien/)** entworfen, den Sie gerne nachnutzen und für Ihre Bedarfe anpassen können. Außerdem steht im September auch unser nächstes Projekttreffen an.
 
 </details>
 
 <details>
-  <summary>**Juli 2018**</summary>
+  <summary><b>Juli 2018</b></summary>
 
 Im Juli haben wir dank diverser Diskussionen mit der Community beschlossen eine eingeschränkte **Mandantenfähigkeit** in RDMO umzusetzen, allerdings voraussichtlich erst im nächsten Jahr. Wir arbeiten intensiv an dem Refractoring des **Datenmodels** und werden bald davon berichten. Außerdem gibt es jetzt zwei **[Videos](/materialien/
 )** zu RDMO, die Sie gerne nachnutzen dürfen.
@@ -424,7 +454,7 @@ Im Juli haben wir dank diverser Diskussionen mit der Community beschlossen eine 
 </details>
 
 <details>
-  <summary>**Juni 2018**</summary>
+  <summary><b>Juni 2018</b></summary>
 
 Im Juni haben wir die Webseite mit Untermenüs versehen, um eine höhrere Übersichtlichkeit zu gewährleisten. So wurde beispielsweise das Thema **[Datenschutz]({{ site.baseurl}}/schutz)** hinzugefügt. Es gibt jetzt eine **Kurzanleitung** zu den Import- und Exportfunktionen: http://www.forschungsdaten.org/index.php/Import_Export . Am 13.06. haben wir ein *[Vortrag](/vorträge/)* über RMDO beim 107. Bibliothekartag gehalten.
 
@@ -432,7 +462,7 @@ Im Juni haben wir die Webseite mit Untermenüs versehen, um eine höhrere Übers
 </details>
 
 <details>
-  <summary>**April & Mai 2018**</summary>
+  <summary><b>April & Mai 2018</b></summary>
 
 Im April haben wir intensiv daran gearbeitet die **Import- und Exportfunktionen** zu verbessern, so dass wir Anfang Mai eine neue RDMO-Version herausbringen konnten. Kleinere Bug-Fixes wurden auch vorgenommen, so dass die aktuelle **Release-Nummer 0.10.2** lautet. Außerdem gibt es jetzt einen **[Flyer]({{site.baseurl}}/materialien)**, den Sie gerne abwandeln und für ihr Institut anpassen dürfen, um so für ihre RDMO-Instanz Werbung zu machen.
 Das Thema Datenschutzes (Stichwort DSGVO) hat uns veranlasst eine Vorschaltseite für die Nutzungsbedingungen einzubauen und ist seit der **Version 0.10.3.** verfügbar.
@@ -440,7 +470,7 @@ Das Thema Datenschutzes (Stichwort DSGVO) hat uns veranlasst eine Vorschaltseite
 </details>
 
 <details>
-  <summary>**März 2018**</summary>
+  <summary><b>März 2018</b></summary>
 
 In diesem Monat waren wir sowohl auf der Open Science Conference 2018 als auch auf dem 11. RDA Plenary vertreten und haben einige anregende Diskussionen geführt. Ein großes Thema sind sogenannte Machine-Actionable DMP (**maDMP**), also machinell auswertbare DMP. In RDMO haben wir von Anfang an die Unterstützung des Workflows während des gesamten Projekts und die Einbindung in Infrastrukturen zum Ziel und sind daher quasi Vorreier auf diesem Gebiet.
 Derzeitige Arbeitsschwerpunkte sind unsere *Softwarearchitektur* bei der wir einen einheitlichen Standard anstreben, weiterhin Vorlagen für *Nutzungsbedingungen* und *Datenschutz* und außerdem stehen jetzt eine [**Postkarte**, ein **Poster** und  **Vortragsfolien**]({{site.baseurl}}/materialien) für die Nachnutzung für Sie zur Verfügung.
@@ -448,7 +478,7 @@ Derzeitige Arbeitsschwerpunkte sind unsere *Softwarearchitektur* bei der wir ein
 </details>
 
 <details>
-  <summary>**Februar 2018**</summary>
+  <summary><b>Februar 2018</b></summary>
 
 Die aktuellen und neuen Mitglieder des RDMO-Projektteams kamen am 8. und 9. Februar 2018  zum **Kickoff-Meeting**
 am Leibniz-Institut für Astrophysik Potsdam (AIP) zusammen.
@@ -462,7 +492,7 @@ Nach einer kurzen Vorstellungrunde machten wir uns ans Werk und einigten uns auf
 </details>
 
 <details>
-  <summary>**Januar 2018**</summary>
+  <summary><b>Januar 2018</b></summary>
 Wir begrüßen unsere neuen **Teammitglieder** Kerstin Vanessa Wedlich (KIT) and Olaf Michaelis (AIP). Während Kerstin sich um die intergration von RDMO in [forschungsdaten.info](http://www.forschungsdaten.info) kümmern wird, wird Olaf die Software weiterentwickeln und den technischen Support unterstützen.
 
 Unsere ersten beiden **Tutorials** zu ["Wie erstelle ich einen Fragenktalog in RDMO?"](http://www.forschungsdaten.org/index.php/Katalog_erstellen) und ["Wie erstelle ich eine Ansicht in RDMO?"](http://www.forschungsdaten.org/index.php/Ansicht_erstellen) wurden veröffentlicht. Eine Seite für [häufig gestellte Fragen (FAQ)](http://www.forschungsdaten.org/index.php/FAQs) ist jetzt ebenfalls verfügbar.

--- a/_data/cg-group.yaml
+++ b/_data/cg-group.yaml
@@ -20,21 +20,21 @@ current:
   image: img/team/lanza.jpg
 
 - text:
-    de: "**Sabine Schönau**" ...
-    en: "**Sabine Schönau**" ...
+    de: "**Sabine Schönau** ... "
+    en: "**Sabine Schönau** ... "
   image:
 
 - text:
-    de: "**Ivonne Anders**" ...
-    en: "**Ivonne Anders**" ...
+    de: "**Ivonne Anders** ... "
+    en: "**Ivonne Anders** ... "
   image:
 
 - text:
-    de: "**Karsten Peters-von Gehlen**" ...
-    en: "**Karsten Peters-von Gehlen**" ...
+    de: "**Karsten Peters-von Gehlen** ... "
+    en: "**Karsten Peters-von Gehlen** ... "
   image:
 
 - text:
-    de: "**Christin Henzen**" ...
-    en: "**Christin Henzen**" ...
+    de: "**Christin Henzen** ... "
+    en: "**Christin Henzen** ... "
   image:

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,6 +1,6 @@
 - name:    Leibniz-Institut für Astrophysik Potsdam (AIP)
   url:     https://rdmo.aip.de
-  contact: Olaf Michaelis, Jochen Klar
+  contact: Olaf Michaelis
   lat:     52.405
   lon:     13.104167
   color:   blue
@@ -9,21 +9,21 @@
 
 - name:    Universitätsallianz Ruhr (Bochum, Duisburg-Essen, Dortmund)
   url:     http://rdmo.uaruhr.de
-  contact: Johannes Frenzel (Ruhr Universität Bochum)
+  contact: [Johannes Frenzel (Ruhr-Universität Bochum)](mailto:researchdata+rdmo@uaruhr.de)
   lat:     51.4439
   lon:     7.261572
   color:   blue
 
 - name:    Universität Duisburg-Essen
-  url:     https://www.uni-due.de/rds
-  contact: Stephanie Rehwald, Sonja Hendriks, Henning Timm
+  # url:     http://rdmo.uaruhr.de
+  contact: [Stephanie Rehwald, Sonja Hendriks, Henning Timm](mailto:)
   lat:     51.429167
   lon:     6.800833
   color:   blue
 
 - name:    IZUS / Universitätsbibliothek Stuttgart
-  url:     http://fdm.ub.uni-stuttgart.de
-  contact: Florian Fritze
+  url:     https://rdmo.forschungsdaten.info/
+  contact: [Sibylle Herrmann, Michael Steigmüller](mailto:fokus@izus.uni-stuttgart.de)
   lat:     48.78231
   lon:     9.1686
   color:   blue
@@ -49,7 +49,7 @@
 
 - name:    Göttingen eResearch Alliance
   url:     https://plan.goettingen-research-online.de/
-  contact: Timo Gnadt, Ubbo Veentjer
+  contact: [Timo Gnadt, Ubbo Veentjer](mailto:info@eresearch.uni-goettingen.de )
   lat:     51.5400097
   lon:     9.9358179
   color:   blue
@@ -66,7 +66,7 @@
 
 - name:    Universitäts- und Landesbibliothek Darmstadt
   url:     http://tudmo.ulb.tu-darmstadt.de
-  contact: Gerald Jagusch
+  contact: [Gerald Jagusch](mailto:tudata@tu-darmstadt.de)
   lat:     49.861429
   lon:     8.680805
   color:   blue
@@ -75,28 +75,29 @@
 #   url:   https://www.tu-dortmund.de/uni/de/Uni
 
 - name:    Universität Düsseldorf (FoDaKo)
-  url:     http://www.fodako.de
+  contact: [](mailto:fdm@hhu.de)
+  url:     https://rdmo.hhu.de/
   lat:     51.1952525
   lon:     6.7899203
   color:   gray
 
 - name:    Universität Wuppertal (FoDaKo)
-  contact: Torsten Rathman
-  url:     http://www.fodako.de
+  contact: [Torsten Rathmann](mailto:fdm@uni-wuppertal.de)
+  url:     https://rdmo.zim.uni-wuppertal.de/
   lat:     51.2458565
   lon:     7.1486939
   color:   gray
 
 - name:    Universität Siegen (FoDaKo)
-  contact: Thomas von Rekowski, Henning Bohn, Volker Hess
-  url:     http://www.fodako.de
+  contact: [Thomas von Rekowski, Henning Bohn, Volker Hess](mailto:info@fodako.nrw)
+  url:     https://rdmo.e-science-service.uni-siegen.de/
   lat:     50.91082
   lon:     8.0273001
   color:   gray
 
 - name:    Universität Hildesheim
-  contact: Annette Strauch
-  # url:     https://www.uni-hildesheim.de/forschungsdaten
+  contact: [Mario Müller](mailto:javascript:linkTo_UnCryptMailto(%27jxfiql7rycrXrkf%3Aefiabpebfj%2Bab%27);)
+  url:     https://dmp.uni-hildesheim.de/
   lat:     52.1600497
   lon:     9.9833092
   color:   gray
@@ -109,35 +110,35 @@
   color:   gray
 
 - name:    Physikalisch-Technische Bundesanstalt Braunschweig (PTB)
-  contact: Giacomo Lanza
+  contact: [Giacomo Lanza](mailto:fdm@ptb.de)
   url:     https://rdmo.ptb.de
   lat:     52.29653
   lon:     10.46418
   color:   blue
 
 - name:    Technische Universität Hamburg
-  contact: Beate Rajski
-  # url:     https://rdmo.rz.tuhh.de
+  contact: [Beate Rajski](mailto:bib-direktion@tuhh.de)
+  url:     https://dmp.fdm.uni-hamburg.de/
   lat:     53.4610079
   lon:     9.9699716
   color:   gray
 
 - name:    Universität Hamburg
-  contact: Kai Wörner
+  contact: [Kai Wörner](mailto:kai.woerner@uni-hamburg.de)
   lat:     53.566298
   lon:     9.984469
   color:   gray
 
 - name:    Universitäts- und Landesbibliothek Münster
-  contact: Marc Schutzeichel
-  url:     https://www.ulb.uni-muenster.de
+  contact: [Marc Schutzeichel](mailto:forschungsdaten@uni-muenster.de)
+  # url:     https://www.ulb.uni-muenster.de
   lat:     51.9627609
   lon:     7.620459
   color:   gray
 
 - name:    Hochschul- und Landesbibliothek Fulda
-  contact: Patrick Langner
-  url:     https://www.hs-fulda.de
+  contact: Patrick Langner](javascript:linkTo_UnCryptMailto(%27nbjmup%2BgpstdivohtebufoAimc%5C%2Fit.gvmeb%5C%2Fef%27);)
+  url:     https://rdmo.hlb.hs-fulda.de/
   lat:     50.5653467
   lon:     9.68746859
   color:   gray
@@ -170,16 +171,18 @@
   color:   blue
 
 - name:    Universität Trier
-  contact: Marina Lemaire, Stefan Kellendonk
+  url:     https://rdmo.uni-trier.de/
+  contact: [Marina Lemaire, Stefan Kellendonk](mailto:esciences@uni-trier.de)
   lat:     49.745933
   lon:     6.688490
   color:   gray
 
-# - name:  Leibnitz-Institut für Pflanzenbiochemie
-#   url:   https://www.uni-trier.de
+- name:  Leibniz-Institut für Pflanzenbiochemie
+#   url:   https://www.ipb-halle.de/forschung/program-center-metacom/forschungsgruppen/computergestuetzte-pflanzenbiochemie/projekte/forschungsdaten/
 
 # - name:  EAWAG
-#   url:   http://www.eawag.ch
+#   url:   https://opendata.eawag.ch/eawagrdm/
+# contact: [](mailto:rdm@eawag.ch)
 
 - name:    Alfred Wegner Institut (AWI)
   contact: Angela Schäfer
@@ -187,14 +190,15 @@
   lon:     8.5805956
   color:   gray
 
-# - name:  Deutsches GeoForschungsZentrum GFZ
-#   contact: Roland Bertelmann
-#   lat:   52.385098
-#   lon:   13.066132
-#   color: gray
+- name:  Deutsches GeoForschungsZentrum GFZ
+  contact: Roland Bertelmann
+  lat:   52.385098
+  lon:   13.066132
+  color: gray
 
 - name:    RTWH Aachen
-  contact: Daniela Hausen
+  url:     https://rdmo.rwth-aachen.de/
+  contact: [Daniela Hausen](mailto:servicedesk@itc.rwth-aachen.de)
   lat:     50.781177
   lon:     6.065603
   color:   gray
@@ -207,7 +211,8 @@
   color:   blue
 
 - name:    Friedrich-Alexander-Universität Erlangen Nürnberg (FAU)
-  contact: Jürgen Rohrwild
+  url:     https://rdmo.ub.fau.de/
+  contact: [Jürgen Rohrwild](mailto:juergen.rohrwild@fau.de)
   lat:     49.597901
   lon:     11.004571
   color:   blue
@@ -219,14 +224,15 @@
   color:   gray
 
 - name:    Staats- und Universitätsbibliothek Dresden (SLUB)
-  contact: Johannes Sperling
+  url:     https://tu-dresden.de/forschung-transfer/services-fuer-forschende/kontaktstelle-forschungsdaten/
+  contact: [Johannes Sperling](mailto:forschungsdaten@slub-dresden.de)
   lat:     51.028183
   lon:     13.736781
   color:   gray
 
 - name:    Universität Potsdam
-  contact: FDM-Team von UB & ZIM forschungsdaten@uni-potsdam.de
-  url:     https://www.uni-potsdam.de/forschungsdaten
+  contact: [Janine Straka, Janna Kienbaum](mailto:forschungsdaten@uni-potsdam.de)
+  url:     https://rdmo.uni-potsdam.de/
   lat:     52.401111
   lon:     13.011944
   color:   gray
@@ -245,8 +251,8 @@
   color: blue
 
 - name: Universität Rostock
-  url: https://www.ub.uni-rostock.de/forschungsdaten
-  contact: Referat Forschungsdaten, Universitätsbibliothek Rostock
+  url: https://rdmo.uni-rostock.de/
+  contact: [Max Schröder](mailto:forschungsdaten@uni-rostock.de)
   lat: 54.088133
   lon: 12.133373
   color: blue
@@ -276,8 +282,8 @@
       öffentliche Repositorien wie GenBank zu unterstützen.
 
 - name: Centre de calcul d'IN2P3
-  url: https://cc.in2p3.fr
-  contact: Yonny Cardenas
+  url: https://dmp.in2p3.fr/
+  contact: [Yonny Cardenas](mailto:cardenas@cc.in2p3.fr)
   lat: 45.7825982
   lon: 4.8651914
   color: gray
@@ -327,7 +333,7 @@
 
 - name: Leuphana Universität Lüneburg
   url: https://rdmo.leuphana.de/
-  # contact:
+  contact: [Servicestelle Forschungsdatenmanagement](mailto:forschungsdaten@leuphana.de)
   lat: 53.228889
   lon: 10.401111
   color: blue
@@ -351,14 +357,14 @@
 
 - name: Max Planck Digital Library
   url: https://rdmo.mpdl.mpg.de/
-  contact: Yves Vincent Grossmann
+  contact: [Yves Vincent Grossmann](mailto:rdmo@mpdl.mpg.de)
   lat: 48.1478564
   lon: 11.5763998
   color: blue
 
 - name: Zuse-Institut Berlin
   url: https://rdmo.zib.de
-  contact: Tim Hasler
+  contact: [Tim Hasler](mailto:rdm@zib.de)
   lat: 52.4560878
   lon: 13.2960695
   color: blue

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -103,7 +103,7 @@
   color:   gray
 
 - name:    Technische Universität Braunschweig
-  contact: Robert Strötgen
+  contact: [Robert Strötgen](forschungsdaten@tu-braunschweig.de)
   url:     https://rdmo.biblio.etc.tu-bs.de
   lat:     52.2735074
   lon:     10.5296839

--- a/aktuelles.md
+++ b/aktuelles.md
@@ -18,85 +18,130 @@ Die [Arbeitsgemeinschaft RDMO]({{ siteurl }}/rdmo_arge) hat sich mit der Veranst
 Für die Verbindungsinformation zu den Workshops und regulären Terminen bitte die RDMO-Arbeitsgemeinschaft oder die jeweiligen Verantwortlichen kontaktieren. Interessierte sind herzlich willkommen.
 
 ## Reguläre RDMO-Videokonferenz-Termine
-(Stand: Dezember 2022)
+(Stand: April 2023)
 
-<table style="width: 100%;">
-<tr style="border:1px solid black;">
-<th style="width: 5%;"></th>
-<th style="width: 15%;"></th>
-<th style="width: 35%;">Fokus</th>
-<th style="width: 20%;">Termin</th>
-<th style="width: 10%;">Protokoll</th>
-<th style="width: 15%;">Ansprechperson</th>
-</tr>
-<tr style="border:1px solid black;">
-<td style="font-weight: bold; padding-left:5px;" colspan="2">Allgemeiner JourFixe</td>
-<td><ul><li>Sprechstunde zur Klärung allgemeiner Fragen</li><li>offen, bei Fragen einfach hinzukommen</li></ul></td>
-<td>am 1. Donnerstag im Monat (11:00-12:00 Uhr)</td>
-<td></td>
-<td><a href="mailto:mail@jochenklar.de">Jochen Klar</a></td>
-</tr> 
-<tr style="border:1px solid black;">
-<td style="font-weight: bold; padding-left:5px;" colspan="2">Softwaregruppe</td>
-<td><ul><li>Austausch über vergangene und zukünftige technische Entwicklungen</li><li>offen, Teilnahme jederzeit möglich</li></ul></td>
-<td>am 3. Donnerstag im Monat (11:00-12:00 Uhr)</td>
-<td><a href="">Link ?</a></td>
-<td><a href="mailto:mail@jochenklar.de">Jochen Klar</a></td>
-</tr>
-<tr style="border:1px solid black;">
-<td style="font-weight: bold; padding-left:5px;" colspan="2">Allgemeine Contentgruppe</td>
-<td><ul><li>Austausch und Anstimmung über inhaltliche Entwicklungsprozesse</li><li>offen, Teilnahme jederzeit möglich</li></ul></td>
-<td>z.Zt. unregelmäßig</td>
-<td><a href="https://docs.google.com/document/d/1DV9vRQDDZnL_LIHBVjMsmRTnbZmvYJ_K0ry8_pXWP50/edit">Link</a></td>
-<td><a href="mailto:kerstin.wedlich@kit.edu">Kerstin Wedlich-Zachodin</a></td>
-</tr>
-<tr style="border:1px solid black; border-bottom-right-radius: 15px;">
-<td></td>
-<td style="font-weight: bold;">UAG Redaktionsprozesse</td>
-<td><ul><li>Umsetzung beschlossener Änderungen inhaltlicher Art</li><li>offen, Teilnahme jederzeit möglich</li></ul></td>
-<td>am 4. Donnerstag im Monat (11:00-12:00 Uhr)</td>
-<td><a href="https://docs.google.com/document/d/1DV9vRQDDZnL_LIHBVjMsmRTnbZmvYJ_K0ry8_pXWP50/edit">Link</a></td>
-<td><a href="mailto:giacomo.lanza@ptb.de">Giacomo Lanza</a></td>
-</tr>
-<tr style="border:1px solid black; border-bottom-right-radius: 15px;">
-<td></td>
-<td style="font-weight: bold;">UAG Website</td>
-<td><ul><li>Aktualisierung der offiziellen Website von RDMO</li><li>offen, Teilnahme jederzeit möglich</li></ul></td>
-<td>am 2. Montag im Monat (10:00-11:00 Uhr)</td>
-<td><a href="https://drive.google.com/drive/folders/1hHJa6_fzgZ7lPewgRzhS50jhKM0Bi0Y9">Link</a></td>
-<td><a href="mailto:schoenau@ub.rwth-aachen.de">Sabine Schönau</a></td>
-</tr>
-<tr style="border:1px solid black; border-bottom-right-radius: 15px;">
-<td></td>
-<td style="font-weight: bold;">UAG DFG Checkliste</td>
-<td><ul><li>Überführung der DFG Checkliste in einen generischen RDMO Katalog samt view</li><li>offen, Teilnahme jederzeit möglich</li></ul></td>
-<td>an jedem 2. Dienstag (15:00-16:00 Uhr)</td>
-<td><a href="https://drive.google.com/drive/folders/1vq4LxMDmr1e9bZLB-6MWXZh5sR-4_ZeC">Link</a></td>
-<td><a href="mailto:giacomo.lanza@ptb.de">Giacomo Lanza</a></td>
-</tr>
-<tr style="border:1px solid grey; border-bottom-right-radius: 15px;">
-<td></td>
-<td style="font-weight: bold; color:grey;">UAG Textanleitungen</td>
-<td style="color:grey;"><ul><li>Erstellung förderspezifischer (formeller) und fachspezifischen (alltauglicher) DMP-Vorgaben und repräsentativer Use Cases</li><li>abgeschlossen, keine Teilnahme mehr möglich</li></ul></td>
-<td style="color:grey;">am 1. Montag im Monat (11:30-12:30)</td>
-<td style="color:grey;"><a style="color:grey;" href="https://docs.google.com/document/d/1mjnkANFwB3FbGx8ytzx8xyJI0XNDr_Hh90IKxliVOLg/edit#heading=h.4l4mo99i5yqh">Link</a></td>
-<td style="color:grey;"><a style="color:grey;" href="mailto:christin.henzen@tu-dresden.de">Christin Henzen</a></td>
-</tr>
-<tr style="border:1px solid grey; border-bottom-right-radius: 15px;">
-<td></td>
-<td style="font-weight: bold; color:grey;">UAG Werbung und Außenkooperationen</td>
-<td style="color:grey;"><ul><li>Zusammenführung der Inhalte und Aktivitäten aus nationalen und internationalen Gruppen</li><li>abgeschlossen, keine Teilnahme mehr möglich</li></ul></td>
-<td style="color:grey;">nicht festgelegt; alle 2 Monate</td>
-<td style="color:grey;"></td>
-<td style="color:grey;"><a style="color:grey;" href="mailto:anders@dkrz.de">Ivonne Anders</a></td>
-</tr>
-<tr style="border:1px solid black;">
-<td style="font-weight: bold; padding-left:5px;" colspan="2">Steuerungsgruppe</td>
-<td><ul><li>Austausch der Steuerungsmitglieder</li><li>nicht öffentlich, keine Teilnahme möglich</li></ul></td>
-<td>am 4. Dienstag im Monat (13:00-14:30)</td>
-<td><a href="">Link ?</a></td>
-<td><a href="mailto:gerald.jagusch@tu-darmstadt.de">Gerald Jagusch</a></td>
-</tr> 
+<table style="width: 100%; border:1px solid black;">
+	<tr>
+		<th style="width: 5%;"/>
+		<th style="width: 15%;"/>
+		<th style="width: 35%;">Fokus</th>
+		<th style="width: 20%;">Termin</th>
+		<th style="width: 10%;">Protokoll</th>
+		<th style="width: 15%;">Ansprechperson</th>
+	</tr>
+	<tr>
+		<td style="font-weight: bold; padding-left:5px;" colspan="2">Allgemeiner JourFixe</td>
+		<td>
+			<ul>
+				<li>Sprechstunde zur Klärung allgemeiner Fragen</li>
+				<li>offen, bei Fragen einfach hinzukommen</li>
+			</ul>
+		</td>
+		<td>am 1. Donnerstag im Monat (11:00-12:00 Uhr)</td>
+		<td/>
+		<td><a href="mailto:mail@jochenklar.de">Jochen Klar</a></td>
+	</tr>
+	<tr>
+		<td style="font-weight: bold; padding-left:5px;" colspan="2">Softwaregruppe</td>
+		<td>
+			<ul>
+				<li>Austausch über vergangene und zukünftige technische Entwicklungen</li>
+				<li>offen, Teilnahme jederzeit möglich</li>
+			</ul>
+		</td>
+		<td>am 3. Donnerstag im Monat (11:00-12:00 Uhr)</td>
+		<td><a href="">Link ?</a></td>
+		<td><a href="mailto:mail@jochenklar.de">Jochen Klar</a></td>
+	</tr>
+	<tr>
+		<td style="font-weight: bold; padding-left:5px;" colspan="2">Allgemeine Contentgruppe</td>
+		<td>
+			<ul>
+				<li>Austausch und Anstimmung über inhaltliche Entwicklungsprozesse</li>
+				<li>offen, Teilnahme jederzeit möglich</li>
+			</ul>
+		</td>
+		<td>z.Zt. unregelmäßig</td>
+		<td><a href="https://docs.google.com/document/d/1DV9vRQDDZnL_LIHBVjMsmRTnbZmvYJ_K0ry8_pXWP50">Link</a></td>
+		<td><a href="mailto:kerstin.wedlich@kit.edu">Kerstin Wedlich-Zachodin</a></td>
+	</tr>
+	<tr style="border-bottom-right-radius: 15px;">
+		<td/>
+		<td style="font-weight: bold;">UAG Redaktionsprozesse</td>
+		<td>
+			<ul>
+				<li>Umsetzung beschlossener Änderungen inhaltlicher Art</li>
+				<li>offen, Teilnahme jederzeit möglich</li>
+			</ul>
+		</td>
+		<td>am 4. Donnerstag im Monat (11:00-12:00 Uhr)</td>
+		<td><a href="https://docs.google.com/document/d/1DV9vRQDDZnL_LIHBVjMsmRTnbZmvYJ_K0ry8_pXWP50">Link</a></td>
+		<td><a href="mailto:giacomo.lanza@ptb.de">Giacomo Lanza</a></td>
+	</tr>
+	<tr style="border-bottom-right-radius: 15px;">
+		<td/>
+		<td style="font-weight: bold;">UAG Website</td>
+		<td>
+			<ul>
+				<li>Aktualisierung der offiziellen Website von RDMO</li>
+				<li>offen, Teilnahme jederzeit möglich</li>
+			</ul>
+		</td>
+		<td>am 2. Montag im Monat (10:00-11:00 Uhr)</td>
+		<td><a href="https://drive.google.com/drive/folders/1hHJa6_fzgZ7lPewgRzhS50jhKM0Bi0Y9">Link</a></td>
+		<td><a href="mailto:schoenau@ub.rwth-aachen.de">Sabine Schönau</a></td>
+	</tr>
+	<tr style="border-bottom-right-radius: 15px; color:grey;">
+		<td/>
+		<td style="font-weight: bold;">UAG DFG Checkliste</td>
+		<td>
+			<ul>
+				<li>Überführung der DFG Checkliste in einen generischen RDMO Katalog samt view</li>
+				<li>abgeschlossen, keine Teilnahme mehr möglich</li>
+			</ul>
+		</td>
+		<td>an jedem 2. Dienstag (15:00-16:00 Uhr)</td>
+		<td><a href="https://drive.google.com/drive/folders/1vq4LxMDmr1e9bZLB-6MWXZh5sR-4_ZeC">Link</a></td>
+		<td><a href="mailto:giacomo.lanza@ptb.de">Giacomo Lanza</a></td>
+	</tr>
+	<tr style="border:1px solid grey; border-bottom-right-radius: 15px; color:grey;">
+		<td/>
+		<td style="font-weight: bold;">UAG Textanleitungen</td>
+		<td>
+			<ul>
+				<li>Erstellung förderspezifischer (formeller) und fachspezifischen (alltauglicher) DMP-Vorgaben und repräsentativer Use Cases</li>
+				<li>abgeschlossen, keine Teilnahme mehr möglich</li>
+			</ul>
+		</td>
+		<td>am 1. Montag im Monat (11:30-12:30)</td>
+		<td><a href="https://docs.google.com/document/d/1mjnkANFwB3FbGx8ytzx8xyJI0XNDr_Hh90IKxliVOLg">Link</a></td>
+		<td><a href="mailto:christin.henzen@tu-dresden.de">Christin Henzen</a></td>
+	</tr>
+	<tr style="border:1px solid grey; border-bottom-right-radius: 15px; color:grey;">
+		<td/>
+		<td style="font-weight: bold;">UAG Werbung und Außenkooperationen</td>
+		<td">
+			<ul>
+				<li>Zusammenführung der Inhalte und Aktivitäten aus nationalen und internationalen Gruppen</li>
+				<li>abgeschlossen, keine Teilnahme mehr möglich</li>
+			</ul>
+		</td>
+		<td>nicht festgelegt; alle 2 Monate</td>
+		<td/>
+		<td><a href="mailto:anders@dkrz.de">Ivonne Anders</a></td>
+	</tr>
+	<tr>
+		<td style="font-weight: bold; padding-left:5px;" colspan="2">Steuerungsgruppe</td>
+		<td>
+			<ul>
+				<li>Austausch der Steuerungsmitglieder</li>
+				<li>nicht öffentlich, keine Teilnahme möglich</li>
+			</ul>
+		</td>
+		<td>am 4. Dienstag im Monat (13:00-14:30)</td>
+		<td><a href="">Link ?</a></td>
+		<td><a href="mailto:gerald.jagusch@tu-darmstadt.de">Gerald Jagusch</a></td>
+	</tr>
 </table>
 
 <br/>
@@ -104,16 +149,14 @@ Für die Verbindungsinformation zu den Workshops und regulären Terminen bitte d
 ## Ankündigungen:
 
 <table style="width: 100%;">
-<tr>
-<th style="width: 10%;"></th>
-<td style="width: 90%; padding-left:10px;"></td>
-</tr>
-<tr style="border-bottom: 1pt solid darkgrey;">
-<th style="width: 10%;">29.03.2022</th>
-<td style="width: 90%; padding-left:10px;"><b>9. RDMO-Community-Treffen (virtuell, 5 Stunden) <br/>
-<br/>
-</td>
-</tr>
+  <tr>
+    <th style="width: 10%;"></th>
+    <td style="width: 90%; padding-left:10px;"></td>
+  </tr>
+  <tr style="border-bottom: 1pt solid darkgrey;">
+    <th style="width: 10%;">29.03.2022</th>
+    <td style="width: 90%; padding-left:10px;"><b>9. RDMO-Community-Treffen (virtuell, 5 Stunden)</td>
+  </tr>
 </table>
 
 
@@ -123,47 +166,55 @@ Die nachfolgende Auflistung enthält alle Bekanntmachungen, Meetings und Worksho
 Informationen rund um die Entwicklung der Software finden Sie auf der Seite [Dokumentation für Admins]({{siteurl}}/Doku_Admins).
 
 <table style="width: 100%;">
-<tr>
-<th style="width: 10%;"></th>
-<td style="width: 90%; padding-left:10px;"></td>
-</tr>
-<tr style="border-bottom: 1pt solid darkgrey;">
-<th style="width: 10%;">13.09.2022</th>
-<td style="width: 90%; padding-left:10px;"><b>8. RDMO-Community-Treffen (virtuell, 4 Stunden) <a href="https://www.forschungsdaten.org/index.php/Achtes_Community-Treffen" target="_blank">Bericht</a></b><br/>
-Unter anderem ging es hier um die Finalisierung der Roadmap. Aber auch aktuelle Herausforderungen wurden diskutiert. Dabei stellte sich heraus, dass die einheitliche Verwendung der DFG Checkliste ein Problem darstellt. Hierfür wurde im Anschluss eine neue Ad hoc-Gruppe innerhalb der RDMO Contentgruppe gebildet, die sich mit dem Umgang mit der DFG Checkliste befasst und einen generischen RDMO Fragenkatalog entwickelt, der alleine oder samt einer passenden view, welche dafür sorgt, dass die Antworten als Fließtext ausgegeben werden, nachgenutzt werden können.<br/>
-Für nähere Informationen können Sie sich die <a href="https://drive.google.com/drive/folders/1vq4LxMDmr1e9bZLB-6MWXZh5sR-4_ZeC" target="_blank">Notizen der UAG DFG Checkliste</a> anschauen, oder die RDMO Arbeitsgemeinschaft anfragen.</td>
-</tr>
-<tr style="border-bottom: 1pt solid darkgrey;">
-<th style="width: 10%;">02.03.2022</th>
-<td style="width: 90%; padding-left:10px;"><b>7. RDMO-Community-Treffen (virtuell, 2.5 Stunden) <a href="https://www.forschungsdaten.org/index.php/Siebtes_Community-Treffen" target="_blank">Bericht</a></b><br/>
-Das Hauptthema dieses Treffen war die Entwicklung eines Roadmap-Prozesses für RDMO zur nutzenden-zentrierten Weiterentwicklung.<br/>
-Agenda:
-<ol>
-<li>Nutzenden getriebene Weiterentwicklung für RDMO (10 min) -> Harry Enke</li>
-<li>Lightning talks (insg. 15 min): </li>
-<ul>
-<li>Content Gruppe: Giacomo Lanza</li>
-<li>Software Gruppe: Jochen Klar</li>
-</ul>
-<li>Breakout Sessions:  Dimensionen einer RDMO Roadmap (2 Räume, 2x 20 min.)(Wechsel der Themen in den Räumen)</li>
-<ul>
-<li>Inhaltliche Dimension - Moderation: Robert Strötgen</li>
-<li>Technische Dimension - Moderation:  Jochen Klar</li>
-</ul>
-<li>gemeinsame Abschlussdiskussion / nächste Schritte (Gerald Jagusch)</li>
-</ol>
-  </td>
-</tr>
-<tr style="border-bottom: 1pt solid darkgrey;">
-<th style="width: 10%;">Februar 2022</th>
-<td style="width: 90%; padding-left:10px;">Auf Vorschlag der Software-Gruppe hat das Steuerungsgremium eine Restrukturierung der RDMO Git-Repositorien und der Personen bzw. Gruppen vorgenommen, die die Bearbeitung der Repositorien regeln. Dabei wurden vor allem die neuen Strukturen der RDMO-Arbeitsgemeinschaft reflektiert.<br/>
-In der NFDI hat sich eine Task Force „DMPs in der NFDI“ innerhalb der NFDI Tools Gruppe formiert. Mitglieder der NFDI-beteiligten Konsortien (/Institute)  können sich über die folgende URL für die Mailing-Liste anmelden: https://lists.nfdi.de/postorius/lists/dmpsindernfdi.lists.nfdi.de
-</td>
-</tr>
-<tr>
-<th style="width: 10%;"></th>
-<td style="width: 90%; padding-left:10px;">Vorherige Ereignisse finden Sie auf der Seite <a href="./Vergangenes.md">Vergangene Veranstaltungen</a>.</td>
-</tr>
+	<tr>
+		<th style="width: 10%;"/>
+		<td style="width: 90%; padding-left:10px;"/>
+	</tr>
+	<tr style="border-bottom: 1pt solid darkgrey;">
+		<th style="width: 10%;">13.09.2022</th>
+		<td style="width: 90%; padding-left:10px;">
+			<b>8. RDMO-Community-Treffen (virtuell, 4 Stunden) <a href="https://www.forschungsdaten.org/index.php/Achtes_Community-Treffen" target="_blank">Bericht</a></b>
+			<br/>
+			Unter anderem ging es hier um die Finalisierung der Roadmap. Aber auch aktuelle Herausforderungen wurden diskutiert. Dabei stellte sich heraus, dass die einheitliche Verwendung der DFG Checkliste ein Problem darstellt. Hierfür wurde im Anschluss eine neue Ad hoc-Gruppe innerhalb der RDMO Contentgruppe gebildet, die sich mit dem Umgang mit der DFG Checkliste befasst und einen generischen RDMO Fragenkatalog entwickelt, der alleine oder samt einer passenden view, welche dafür sorgt, dass die Antworten als Fließtext ausgegeben werden, nachgenutzt werden können.
+			<br/>
+			Für nähere Informationen können Sie sich die <a href="https://drive.google.com/drive/folders/1vq4LxMDmr1e9bZLB-6MWXZh5sR-4_ZeC" target="_blank">Notizen der UAG DFG Checkliste</a> anschauen, oder die RDMO Arbeitsgemeinschaft anfragen.
+		</td>
+	</tr>
+	<tr style="border-bottom: 1pt solid darkgrey;">
+		<th style="width: 10%;">02.03.2022</th>
+		<td style="width: 90%; padding-left:10px;">
+			<b>7. RDMO-Community-Treffen (virtuell, 2.5 Stunden) <a href="https://www.forschungsdaten.org/index.php/Siebtes_Community-Treffen" target="_blank">Bericht</a></b>
+			<br/>
+			Das Hauptthema dieses Treffen war die Entwicklung eines Roadmap-Prozesses für RDMO zur nutzenden-zentrierten Weiterentwicklung.
+			<br/>
+			Agenda:
+			<ol>
+				<li>Nutzenden getriebene Weiterentwicklung für RDMO (10 min) -> Harry Enke</li>
+				<li>Lightning talks (insg. 15 min): </li>
+				<ul>
+					<li>Content Gruppe: Giacomo Lanza</li>
+					<li>Software Gruppe: Jochen Klar</li>
+				</ul>
+				<li>Breakout Sessions:  Dimensionen einer RDMO Roadmap (2 Räume, 2x 20 min.)(Wechsel der Themen in den Räumen)</li>
+				<ul>
+					<li>Inhaltliche Dimension - Moderation: Robert Strötgen</li>
+					<li>Technische Dimension - Moderation: Jochen Klar</li>
+				</ul>
+				<li>gemeinsame Abschlussdiskussion / nächste Schritte (Gerald Jagusch)</li>
+			</ol>
+		</td>
+	</tr>
+	<tr style="border-bottom: 1pt solid darkgrey;">
+		<th style="width: 10%;">Februar 2022</th>
+		<td style="width: 90%; padding-left:10px;">Auf Vorschlag der Software-Gruppe hat das Steuerungsgremium eine Restrukturierung der RDMO Git-Repositorien und der Personen bzw. Gruppen vorgenommen, die die Bearbeitung der Repositorien regeln. Dabei wurden vor allem die neuen Strukturen der RDMO-Arbeitsgemeinschaft reflektiert.
+		<br/>
+		In der NFDI hat sich eine Task Force „DMPs in der NFDI“ innerhalb der NFDI Tools Gruppe formiert. Mitglieder der NFDI-beteiligten Konsortien (/Institute)  können sich über die folgende URL für die Mailing-Liste anmelden: https://lists.nfdi.de/postorius/lists/dmpsindernfdi.lists.nfdi.de
+		</td>
+	</tr>
+	<tr>
+		<th style="width: 10%;"/>
+		<td style="width: 90%; padding-left:10px;">Vorherige Ereignisse finden Sie auf der Seite <a href="./Vergangenes.md">Vergangene Veranstaltungen</a>.</td>
+	</tr>
 </table>
 
 

--- a/aktuelles.md
+++ b/aktuelles.md
@@ -91,13 +91,13 @@ Für die Verbindungsinformation zu den Workshops und regulären Terminen bitte d
 		<td><a href="https://drive.google.com/drive/folders/1hHJa6_fzgZ7lPewgRzhS50jhKM0Bi0Y9">Link</a></td>
 		<td><a href="mailto:schoenau@ub.rwth-aachen.de">Sabine Schönau</a></td>
 	</tr>
-	<tr style="border-bottom-right-radius: 15px; color:grey;">
+	<tr style="border-bottom-right-radius: 15px;">
 		<td/>
 		<td style="font-weight: bold;">UAG DFG Checkliste</td>
 		<td>
 			<ul>
 				<li>Überführung der DFG Checkliste in einen generischen RDMO Katalog samt view</li>
-				<li>abgeschlossen, keine Teilnahme mehr möglich</li>
+				<li>offen, Teilnahme jederzeit möglich</li>
 			</ul>
 		</td>
 		<td>an jedem 2. Dienstag (15:00-16:00 Uhr)</td>

--- a/aktuelles.md
+++ b/aktuelles.md
@@ -204,13 +204,6 @@ Informationen rund um die Entwicklung der Software finden Sie auf der Seite [Dok
 			</ol>
 		</td>
 	</tr>
-	<tr style="border-bottom: 1pt solid darkgrey;">
-		<th style="width: 10%;">Februar 2022</th>
-		<td style="width: 90%; padding-left:10px;">Auf Vorschlag der Software-Gruppe hat das Steuerungsgremium eine Restrukturierung der RDMO Git-Repositorien und der Personen bzw. Gruppen vorgenommen, die die Bearbeitung der Repositorien regeln. Dabei wurden vor allem die neuen Strukturen der RDMO-Arbeitsgemeinschaft reflektiert.
-		<br/>
-		In der NFDI hat sich eine Task Force „DMPs in der NFDI“ innerhalb der NFDI Tools Gruppe formiert. Mitglieder der NFDI-beteiligten Konsortien (/Institute)  können sich über die folgende URL für die Mailing-Liste anmelden: https://lists.nfdi.de/postorius/lists/dmpsindernfdi.lists.nfdi.de
-		</td>
-	</tr>
 	<tr>
 		<th style="width: 10%;"/>
 		<td style="width: 90%; padding-left:10px;">Vorherige Ereignisse finden Sie auf der Seite <a href="./Vergangenes.md">Vergangene Veranstaltungen</a>.</td>


### PR DESCRIPTION
## Startseite

- [x] Partner mit Funktionsadressen versehen

~[ ] Partner sortieren~

## Aktuelles

- [x] Tabelle formatieren
- [ ] Kontakte lieber über Funktionsadressen
- [ ] Aktuelles Datum des nächsten Treffens?
- [ ] Ankündigungen ergänzen

~[ ] Protokolle im Lesemodus --> das muss der Doku-Besitzer festlegen~

## Vergangene Veranstaltungen

- [x] Menü und Monatsmails aufklappbar
- [x] Terminübersicht harmonisieren
- [ ] Bibliographie aktualisieren (über Zotero?)

## Community / RDMO Arbeitsgemeinschaft

RDMO Arbeitsgemeinschaft
- [ ] Bunte, aktuelle Fotos
- [ ] Einheitliche Beschreibungen, so kurz wie möglich: Namen, Institution, ggf. ORCID/CrossRef-Profil. Vorbild: Olaf
- [ ] Representativität: engagierte Mitglieder hinzufügen
- [x] Mailinglisten hervorheben (“So erreichen Sie die Steuerungsgruppe…”, ggf. Fußzeile)

## Weiteres
- [x] Kohärente Titelgrößen

Ein teil davon bereits im Commit [cbd4888](https://github.com/Sabine-Schoenau/rdmorganiser.github.io/commit/cbd4888a1e31bfcb2b8f9b853172fe382456f683) implementiert